### PR TITLE
Contributorへの追加申請

### DIFF
--- a/src/Version.cc
+++ b/src/Version.cc
@@ -23,7 +23,7 @@ void print_version(const char* program_name, FILE* output)
   if (output == stderr)
     {
       fprintf(output, "%sThanks to all contributors:\n", comment);
-      fprintf(output, "%s    KAWAMOTO,Takuto       Kunihiro AIHARA\n", comment);
+      fprintf(output, "%s    KAWAMOTO,Takuto       Kunihiro AIHARA       Yuji Nomura\n", comment);
     }
 }
 


### PR DESCRIPTION
恐縮です。

ところで、もう１つ報告事項があります。

WindowsXP + VMWare 5.5 + FreeBSD 9.3 の環境で、`pkg install qt5 libGLU povray37`として
(a) `gmake CC=clang CXX=clang++ Qt`
(b) `gmake Qt`
すると、以下2点の問題が起こりました。

・(a)(b)共に、/usr/local/includeがINCLUDE_PATHに入ってなくて 'GL/gl.h' file not found に、
　/usr/local/libがLIBRARY_PATHに入ってなくて-lGLUがリンクエラーになりました。
　src/Qt/FullereneViewer.pro の!macx:unix{}の所を
    INCLUDEPATH += /usr/local/include
    LIBS += -L/usr/local/lib -lGLU
　にすると、コンパイルが通りました。
　
・(a)でできた実行ファイルは、起動時にBus errorで落ちました。
　gdbで止めてみましたが、シンボル付きの実行ファイルなのにシンボルが一切表示されず、何も分かりませんでした。
　(b)でできた実行ファイルは、正常に起動しました。

以上、Mac + VirtualBox + FreeBSD 9.3でも、同じでした。
別件なので、Issue #49には書きませんでした。

よろしくお願い致します。
